### PR TITLE
Initial attempt at supporting channels

### DIFF
--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
+## Unreleased
+- Support for tracking channels per repository/extension.
+
 ## 0.9.0-beta.0
 
 - Initial release
-  - Support for tracking channels per repository/extension.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Change Log
 
-## 0.9.0
-- Support for tracking channels per repository/extension.
-
 ## Unreleased
 
 - Initial release
+  - Support for tracking channels per repository/extension.

--- a/extension/CHANGELOG.md
+++ b/extension/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.9.0
+- Support for tracking channels per repository/extension.
+
 ## Unreleased
 
 - Initial release

--- a/extension/README.md
+++ b/extension/README.md
@@ -167,7 +167,7 @@ To specify a channel to track for an extension, add it to the `privateExtensions
     "publisherOne.extensionTwo": "1.0.0"       // Pins the extension to version 1.0.0
 }
 ```
-Note that the key is the extension's npm package ID (`publisherName.packageID`) and the value is the desired channel.
+Note that the key is the extension identifier (given as '${publisher}.${name}') and the value is the desired channel.
 
 *Publishing to a Channel*<br>
 To publish an extension to a channel, simply specify the channel name using

--- a/extension/README.md
+++ b/extension/README.md
@@ -113,7 +113,11 @@ The file has the following structure:
     "registries": [
         {
             "name": "My Private Registry",
-            "registry": "https://my-private.registry"
+            "registry": "https://my-private.registry",
+            "channels": {
+                "extension1": "latest",
+                "extension2": "insiders"
+            }
         }
     ],
     "recommendations": [
@@ -132,6 +136,13 @@ extensions. Each item supports the following fields:
     This is either an array of search terms or a string with space-delimited terms.
     For example, `"keywords:group1 keywords:group2"` would display only packages
     that have the either of the keywords `group1` or `group2`.
+* **channels**: (Optional) An object describing which channels should be subscribed to for extensions in the repository.
+    The key is the extension ID and the value is the desired channel.  To publish an extension to a channel, simply specify the channel name using
+    [npm dist-tags](https://docs.npmjs.com/cli/dist-tag) when publishing.  By default, all packages will reference the `latest` tag.
+    ```
+    npm publish . --tag=insiders
+    ```
+    When publishing pre-release versions, it is also reccomended to use pre-release sematic-versioning, such as 1.0.0-beta.0.
 * Any options supported by [npm-registry-fetch](https://github.com/npm/npm-registry-fetch#-fetch-options).
     Use these if you need to set authentication, a proxy, or other options.
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -114,10 +114,6 @@ The file has the following structure:
         {
             "name": "My Private Registry",
             "registry": "https://my-private.registry",
-            "channels": {
-                "extension1": "latest",
-                "extension2": "insiders"
-            }
         }
     ],
     "recommendations": [
@@ -136,13 +132,6 @@ extensions. Each item supports the following fields:
     This is either an array of search terms or a string with space-delimited terms.
     For example, `"keywords:group1 keywords:group2"` would display only packages
     that have the either of the keywords `group1` or `group2`.
-* **channels**: (Optional) An object describing which channels should be subscribed to for extensions in the repository.
-    The key is the extension ID and the value is the desired channel.  To publish an extension to a channel, simply specify the channel name using
-    [npm dist-tags](https://docs.npmjs.com/cli/dist-tag) when publishing.  By default, all packages will reference the `latest` tag.
-    ```
-    npm publish . --tag=insiders
-    ```
-    When publishing pre-release versions, it is also reccomended to use pre-release sematic-versioning, such as 1.0.0-beta.0.
 * Any options supported by [npm-registry-fetch](https://github.com/npm/npm-registry-fetch#-fetch-options).
     Use these if you need to set authentication, a proxy, or other options.
 
@@ -163,6 +152,30 @@ as the `registries` array in `extensions.private.json`.
 
 You can use the **Private Extensions: Add Registry...** and
 **Private Extensions: Remove Registry** commands to quickly edit this setting.
+
+#### Custom Channels
+It is possible to create tracking channels by using npm dist-tags when
+publishing a private extension. The tracked channel is used to determine when
+extension updates are available.
+
+*Tracking a Channel*<br>
+To specify a channel to track for an extension, add it to the `privateExtensions.channels` settings object as shown in the example below:
+```
+"privateExtensions.channels" :{
+    "extensionOne": "insiders",     // Tracks the 'insiders' dist-tag
+    "extensionTwo": "beta",         // Tracks the 'beta' dist-tag
+    "extensionThree": "1.0.0"       // Pins the extension to version 1.0.0
+}
+```
+Note that the key is the extension's npm package ID and the value is the desired channel.
+
+*Publishing to a Channel*<br>
+To publish an extension to a channel, simply specify the channel name using
+[npm dist-tags](https://docs.npmjs.com/cli/dist-tag) when publishing.  By default, all packages will reference the `latest` tag.
+```
+npm publish . --tag=insiders
+```
+When publishing pre-release versions, it is reccomended to use pre-release sematic-versioning, such as **1.0.0-beta.0**.
 
 ## Remote Development
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -162,12 +162,12 @@ extension updates are available.
 To specify a channel to track for an extension, add it to the `privateExtensions.channels` settings object as shown in the example below:
 ```
 "privateExtensions.channels" :{
-    "extensionOne": "insiders",     // Tracks the 'insiders' dist-tag
-    "extensionTwo": "beta",         // Tracks the 'beta' dist-tag
-    "extensionThree": "1.0.0"       // Pins the extension to version 1.0.0
+    "publisherOne.extensionOne": "insiders",     // Tracks the 'insiders' dist-tag
+    "publisherTwo.extensionOne": "beta",         // Tracks the 'beta' dist-tag
+    "publisherOne.extensionTwo": "1.0.0"       // Pins the extension to version 1.0.0
 }
 ```
-Note that the key is the extension's npm package ID and the value is the desired channel.
+Note that the key is the extension's npm package ID (`publisherName.packageID`) and the value is the desired channel.
 
 *Publishing to a Channel*<br>
 To publish an extension to a channel, simply specify the channel name using

--- a/extension/package.json
+++ b/extension/package.json
@@ -64,6 +64,11 @@
                     "scope": "machine",
                     "description": "%configuration.registries.description%"
                 },
+                "privateExtensions.channels": {
+                    "type": "object",
+                    "scope": "machine",
+                    "description": "%configuration.channels.description%"
+                },
                 "privateExtensions.updateCheckInterval": {
                     "type": "number",
                     "scope": "machine",

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -1,6 +1,7 @@
 {
     "configuration.title": "Private Extensions",
     "configuration.registries.description": "NPM registries containing private extensions. Same format as \"registries\" in extensions.private.json.",
+    "configuration.channels.description": "Channels to track for each extension. Keys are the extension package name and values are the target channel. By default extensions track the 'latest' channel.",
     "configuration.updateCheckInterval.description": "Number of seconds between checks for updates to private extensions. Set to 0 to disable automatic update checks.",
     "command.category": "Private Extensions",
     "command.checkForUpdates.title": "Check for Extension Updates",

--- a/extension/src/Package.ts
+++ b/extension/src/Package.ts
@@ -91,6 +91,8 @@ export class Package {
     public readonly version: SemVer;
     /** The registry containing the extension. */
     public readonly registry: Registry;
+    /* The channel that this package is tracking */
+    public readonly channel: string;
 
     private readonly vsixFile: string | null;
     private readonly isPublisherValid: boolean;
@@ -105,7 +107,7 @@ export class Package {
      * @param manifest The version-specific package manifest for the extension.
      * @throws {NotAnExtensionError} `manifest` is not a Visual Studio Code extension.
      */
-    constructor(registry: Registry, manifest: Record<string, unknown>) {
+    constructor(registry: Registry, manifest: Record<string, unknown>, channel: string = 'latest') {
         this.registry = registry;
 
         assertType(manifest, PackageManifest);
@@ -118,6 +120,7 @@ export class Package {
         );
 
         this.name = manifest.name;
+        this.channel = channel;
         this.displayName = manifest.displayName ?? this.name;
 
         // VS Code uses case-insensitive comparison to match extension IDs.

--- a/extension/src/Package.ts
+++ b/extension/src/Package.ts
@@ -105,6 +105,7 @@ export class Package {
     /**
      * @param registry The `Registry` that contains the package.
      * @param manifest The version-specific package manifest for the extension.
+     * @param channel The NPM dist-tag this package is tracking, or a specific version it is pinned to.
      * @throws {NotAnExtensionError} `manifest` is not a Visual Studio Code extension.
      */
     constructor(registry: Registry, manifest: Record<string, unknown>, channel: string = 'latest') {

--- a/extension/src/Registry.ts
+++ b/extension/src/Registry.ts
@@ -164,8 +164,7 @@ export class Registry {
             }
 
             try {
-                const pkg = await this.getPackageVersionMetadata(result.name);
-                packages.push(pkg);
+                packages.push(await this.getPackage(result.name));
             } catch (ex) {
                 if (ex instanceof NotAnExtensionError) {
                     // Package is not an extension. Ignore.
@@ -178,7 +177,7 @@ export class Registry {
                     window.showErrorMessage(
                         localize(
                             'invalid.channel',
-                            '{0} Your "privateExtensions.channels" setting may be invalid.  {1} to fix.',
+                            '{0} Your "privateExtensions.channels" setting may be invalid. {1} to fix.',
                             ex.message,
                             settingsJsonLink,
                         ),
@@ -226,11 +225,14 @@ export class Registry {
      * If `version` is omitted, this gets the latest version for the user's selected channel.
      * @throws VersionMissingError if the given version does not exist.
      */
-    public async getPackageVersionMetadata(name: string, version?: string) {
+    public async getPackage(name: string, version?: string) {
         const metadata = await this.getPackageMetadata(name);
 
         assertType(metadata, PackageVersionData, `In package "${name}"`);
 
+        // Publisher is only available in the version-specific metadata
+        // Try to get publisher from latest release and use that to
+        // check for user-specified tracking channel.
         if (version === undefined) {
             const latest = lookupVersion(metadata, name, 'latest');
             if (typeof latest.publisher === 'string') {

--- a/extension/src/Registry.ts
+++ b/extension/src/Registry.ts
@@ -82,6 +82,7 @@ export class Registry {
     constructor(
         public readonly name: string,
         public readonly source: RegistrySource,
+        public readonly channels: any,
         options: Partial<RegistryOptions & Options>,
     ) {
         const { query, ...searchOpts } = options;
@@ -90,6 +91,7 @@ export class Registry {
         // leave the search text blank, it will return nothing.
         this.query = query ?? '*';
         this.options = searchOpts;
+        this.channels = channels;
 
         this.options.cache = getNpmCacheDir();
     }
@@ -152,8 +154,12 @@ export class Registry {
             }
 
             try {
-                const manifest = await this.getPackageVersionMetadata(result.name, 'latest');
-                packages.push(new Package(this, manifest));
+                let channel = 'latest';
+                if (this.channels && this.channels[result.name]) {
+                    channel = this.channels[result.name];
+                }
+                const manifest = await this.getPackageVersionMetadata(result.name, channel);
+                packages.push(new Package(this, manifest, channel));
             } catch (ex) {
                 if (ex instanceof NotAnExtensionError) {
                     // Package is not an extension. Ignore.

--- a/extension/src/RegistryProvider.ts
+++ b/extension/src/RegistryProvider.ts
@@ -18,6 +18,7 @@ const UserRegistry = options(
     },
     {
         registry: t.string,
+        channels: t.object,
     },
 );
 type UserRegistry = t.TypeOf<typeof UserRegistry>;
@@ -191,8 +192,8 @@ export class RegistryProvider implements Disposable {
         const userRegistries = this.getUserRegistryConfig();
 
         for (const item of userRegistries) {
-            const { name, ...options } = item;
-            this.userRegistries.push(new Registry(name, RegistrySource.User, options));
+            const { name, channels, ...options } = item;
+            this.userRegistries.push(new Registry(name, RegistrySource.User, channels, options));
         }
     }
 
@@ -328,8 +329,8 @@ class FolderRegistryProvider implements Disposable {
 
         if (config.registries) {
             for (const registry of config.registries) {
-                const { name, ...options } = registry;
-                this.registries.push(new Registry(name, RegistrySource.Workspace, options));
+                const { name, channels, ...options } = registry;
+                this.registries.push(new Registry(name, RegistrySource.Workspace, channels, options));
             }
         }
 

--- a/extension/src/RegistryProvider.ts
+++ b/extension/src/RegistryProvider.ts
@@ -18,7 +18,6 @@ const UserRegistry = options(
     },
     {
         registry: t.string,
-        channels: t.object,
     },
 );
 type UserRegistry = t.TypeOf<typeof UserRegistry>;
@@ -192,13 +191,16 @@ export class RegistryProvider implements Disposable {
         const userRegistries = this.getUserRegistryConfig();
 
         for (const item of userRegistries) {
-            const { name, channels, ...options } = item;
-            this.userRegistries.push(new Registry(name, RegistrySource.User, channels, options));
+            const { name, ...options } = item;
+            this.userRegistries.push(new Registry(name, RegistrySource.User, options));
         }
     }
 
     private onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent) {
-        if (e.affectsConfiguration('privateExtensions.registries')) {
+        if (
+            e.affectsConfiguration('privateExtensions.registries') ||
+            e.affectsConfiguration('privateExtensions.channels')
+        ) {
             this.isStale = true;
             this._onDidChangeRegistries.fire();
         }
@@ -329,8 +331,8 @@ class FolderRegistryProvider implements Disposable {
 
         if (config.registries) {
             for (const registry of config.registries) {
-                const { name, channels, ...options } = registry;
-                this.registries.push(new Registry(name, RegistrySource.Workspace, channels, options));
+                const { name, ...options } = registry;
+                this.registries.push(new Registry(name, RegistrySource.Workspace, options));
             }
         }
 

--- a/extension/src/findPackage.ts
+++ b/extension/src/findPackage.ts
@@ -1,7 +1,6 @@
 import * as npa from 'npm-package-arg';
 import * as nls from 'vscode-nls';
 
-import { Package } from './Package';
 import { Registry, VersionInfo } from './Registry';
 import { RegistryProvider } from './RegistryProvider';
 
@@ -77,8 +76,8 @@ async function _findVersions(registries: readonly Registry[], name: string) {
 
 async function tryGetPackage(registry: Registry, name: string, version: string) {
     try {
-        const manifest = await registry.getPackageVersionMetadata(name, version);
-        return new Package(registry, manifest);
+        const pkg = await registry.getPackageVersionMetadata(name, version);
+        return pkg;
     } catch (ex) {
         if (ex.statusCode === 404) {
             // Ignore 404 errors. The registry does not have the package.

--- a/extension/src/findPackage.ts
+++ b/extension/src/findPackage.ts
@@ -76,8 +76,7 @@ async function _findVersions(registries: readonly Registry[], name: string) {
 
 async function tryGetPackage(registry: Registry, name: string, version: string) {
     try {
-        const pkg = await registry.getPackageVersionMetadata(name, version);
-        return pkg;
+        return await registry.getPackage(name, version);
     } catch (ex) {
         if (ex.statusCode === 404) {
             // Ignore 404 errors. The registry does not have the package.

--- a/extension/src/test/suite/package.test.ts
+++ b/extension/src/test/suite/package.test.ts
@@ -544,7 +544,7 @@ suite('Package', function() {
  * tests on `Package` objects.
  */
 function getDummyRegistry() {
-    return new Registry('test', RegistrySource.Workspace, {
+    return new Registry('test', RegistrySource.Workspace, 'latest', {
         registry: 'localhost',
     });
 }

--- a/extension/src/test/suite/package.test.ts
+++ b/extension/src/test/suite/package.test.ts
@@ -544,7 +544,7 @@ suite('Package', function() {
  * tests on `Package` objects.
  */
 function getDummyRegistry() {
-    return new Registry('test', RegistrySource.Workspace, 'latest', {
+    return new Registry('test', RegistrySource.Workspace, {
         registry: 'localhost',
     });
 }

--- a/extension/src/test/suite/registry.test.ts
+++ b/extension/src/test/suite/registry.test.ts
@@ -158,13 +158,13 @@ suite('Registry Package Search', function() {
             registry: REGISTRY_URL,
         });
 
-        const latest = new Package(registry, await registry.getPackageVersionMetadata('baz', 'latest'));
+        const latest = await registry.getPackageVersionMetadata('baz', 'latest');
         assert.deepInclude(latest, EXPECT.baz);
 
-        const versionOne = new Package(registry, await registry.getPackageVersionMetadata('baz', '1.0.0'));
+        const versionOne = await registry.getPackageVersionMetadata('baz', '1.0.0');
         assert.deepInclude(versionOne, EXPECT.baz_old);
 
-        const versionTwo = new Package(registry, await registry.getPackageVersionMetadata('baz', '2.0.0'));
+        const versionTwo = await registry.getPackageVersionMetadata('baz', '2.0.0');
         assert.deepInclude(versionTwo, EXPECT.baz);
     });
 });

--- a/extension/src/test/suite/registry.test.ts
+++ b/extension/src/test/suite/registry.test.ts
@@ -60,7 +60,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Create registry', async function() {
-        const registry = new Registry('test', RegistrySource.Workspace, {
+        const registry = new Registry('test', RegistrySource.Workspace, 'latest', {
             registry: REGISTRY_URL,
             query: 'query',
             otp: 123456,
@@ -76,7 +76,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get all packages', async function() {
-        const registry = new Registry('test', RegistrySource.User, {
+        const registry = new Registry('test', RegistrySource.User, 'latest', {
             registry: REGISTRY_URL,
         });
 
@@ -88,7 +88,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get keyword 1', async function() {
-        const registry = new Registry('test', RegistrySource.User, {
+        const registry = new Registry('test', RegistrySource.User, 'latest', {
             registry: REGISTRY_URL,
             query: 'keywords:foo',
         });
@@ -101,7 +101,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get keyword 2', async function() {
-        const registry = new Registry('test', RegistrySource.User, {
+        const registry = new Registry('test', RegistrySource.User, 'latest', {
             registry: REGISTRY_URL,
             query: 'keywords:bar',
         });
@@ -114,7 +114,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get keyword 3', async function() {
-        const registry = new Registry('test', RegistrySource.User, {
+        const registry = new Registry('test', RegistrySource.User, 'latest', {
             registry: REGISTRY_URL,
             query: 'keywords:b-packages',
         });
@@ -127,7 +127,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get two keywords with string', async function() {
-        const registry = new Registry('test', RegistrySource.User, {
+        const registry = new Registry('test', RegistrySource.User, 'latest', {
             registry: REGISTRY_URL,
             query: 'keywords:foo keywords:bar',
         });
@@ -141,7 +141,7 @@ suite('Registry Package Search', function() {
 
     test('Get two keywords with array', async function() {
         // query = ['term1', 'term2'] should be identical to 'term1 term2'.
-        const registry = new Registry('test', RegistrySource.User, {
+        const registry = new Registry('test', RegistrySource.User, 'latest', {
             registry: REGISTRY_URL,
             query: ['keywords:foo', 'keywords:bar'],
         });
@@ -154,7 +154,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get package metadata', async function() {
-        const registry = new Registry('test', RegistrySource.User, {
+        const registry = new Registry('test', RegistrySource.User, 'latest', {
             registry: REGISTRY_URL,
         });
 

--- a/extension/src/test/suite/registry.test.ts
+++ b/extension/src/test/suite/registry.test.ts
@@ -60,7 +60,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Create registry', async function() {
-        const registry = new Registry('test', RegistrySource.Workspace, 'latest', {
+        const registry = new Registry('test', RegistrySource.Workspace, {
             registry: REGISTRY_URL,
             query: 'query',
             otp: 123456,
@@ -76,7 +76,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get all packages', async function() {
-        const registry = new Registry('test', RegistrySource.User, 'latest', {
+        const registry = new Registry('test', RegistrySource.User, {
             registry: REGISTRY_URL,
         });
 
@@ -88,7 +88,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get keyword 1', async function() {
-        const registry = new Registry('test', RegistrySource.User, 'latest', {
+        const registry = new Registry('test', RegistrySource.User, {
             registry: REGISTRY_URL,
             query: 'keywords:foo',
         });
@@ -101,7 +101,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get keyword 2', async function() {
-        const registry = new Registry('test', RegistrySource.User, 'latest', {
+        const registry = new Registry('test', RegistrySource.User, {
             registry: REGISTRY_URL,
             query: 'keywords:bar',
         });
@@ -114,7 +114,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get keyword 3', async function() {
-        const registry = new Registry('test', RegistrySource.User, 'latest', {
+        const registry = new Registry('test', RegistrySource.User, {
             registry: REGISTRY_URL,
             query: 'keywords:b-packages',
         });
@@ -127,7 +127,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get two keywords with string', async function() {
-        const registry = new Registry('test', RegistrySource.User, 'latest', {
+        const registry = new Registry('test', RegistrySource.User, {
             registry: REGISTRY_URL,
             query: 'keywords:foo keywords:bar',
         });
@@ -141,7 +141,7 @@ suite('Registry Package Search', function() {
 
     test('Get two keywords with array', async function() {
         // query = ['term1', 'term2'] should be identical to 'term1 term2'.
-        const registry = new Registry('test', RegistrySource.User, 'latest', {
+        const registry = new Registry('test', RegistrySource.User, {
             registry: REGISTRY_URL,
             query: ['keywords:foo', 'keywords:bar'],
         });
@@ -154,7 +154,7 @@ suite('Registry Package Search', function() {
     });
 
     test('Get package metadata', async function() {
-        const registry = new Registry('test', RegistrySource.User, 'latest', {
+        const registry = new Registry('test', RegistrySource.User, {
             registry: REGISTRY_URL,
         });
 

--- a/extension/src/test/suite/registry.test.ts
+++ b/extension/src/test/suite/registry.test.ts
@@ -158,13 +158,13 @@ suite('Registry Package Search', function() {
             registry: REGISTRY_URL,
         });
 
-        const latest = await registry.getPackageVersionMetadata('baz', 'latest');
+        const latest = await registry.getPackage('baz', 'latest');
         assert.deepInclude(latest, EXPECT.baz);
 
-        const versionOne = await registry.getPackageVersionMetadata('baz', '1.0.0');
+        const versionOne = await registry.getPackage('baz', '1.0.0');
         assert.deepInclude(versionOne, EXPECT.baz_old);
 
-        const versionTwo = await registry.getPackageVersionMetadata('baz', '2.0.0');
+        const versionTwo = await registry.getPackage('baz', '2.0.0');
         assert.deepInclude(versionTwo, EXPECT.baz);
     });
 });

--- a/extension/src/test/suite/registryProvider.test.ts
+++ b/extension/src/test/suite/registryProvider.test.ts
@@ -119,7 +119,7 @@ suite('Registry Provider', function() {
         });
 
         const provider = new RegistryProvider();
-        const type = 'Array<{ name: string, registry?: string }>';
+        const type = 'Array<{ name: string, registry?: string, channels?: object }>';
 
         assert.throws(
             () => {

--- a/extension/src/test/suite/registryProvider.test.ts
+++ b/extension/src/test/suite/registryProvider.test.ts
@@ -115,7 +115,7 @@ suite('Registry Provider', function() {
     });
 
     test('Tracking custom channel', async function() {
-        stubGlobalConfiguration('privateExtensions', USER_REGISTRY_CONFIG_CHNL);
+        stubGlobalConfiguration('privateExtensions', USER_REGISTRY_CONFIG_CHANNEL);
 
         const provider = new RegistryProvider();
         const packages = await provider.getUniquePackages();
@@ -231,7 +231,7 @@ const USER_REGISTRY_CONFIG = {
     ],
 };
 
-const USER_REGISTRY_CONFIG_CHNL = {
+const USER_REGISTRY_CONFIG_CHANNEL = {
     registries: [
         {
             name: 'User Registry',

--- a/extension/src/test/suite/registryProvider.test.ts
+++ b/extension/src/test/suite/registryProvider.test.ts
@@ -239,7 +239,7 @@ const USER_REGISTRY_CONFIG_CHNL = {
         },
     ],
     channels: {
-        test: 'insiders',
+        'test.test': 'insiders',
     },
 };
 

--- a/extension/src/test/suite/registryProvider.test.ts
+++ b/extension/src/test/suite/registryProvider.test.ts
@@ -4,6 +4,7 @@ import * as chaiSubsetInOrder from 'chai-subset-in-order';
 import * as search from 'libnpmsearch';
 import { after, afterEach, before, beforeEach } from 'mocha';
 import * as nock from 'nock';
+import { SemVer } from 'semver';
 import * as sinon from 'sinon';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
@@ -113,13 +114,31 @@ suite('Registry Provider', function() {
         assert.lengthOf(packages, expected.length);
     });
 
+    test('Tracking custom channel', async function() {
+        stubGlobalConfiguration('privateExtensions', USER_REGISTRY_CONFIG_CHNL);
+
+        const provider = new RegistryProvider();
+        const packages = await provider.getUniquePackages();
+        packages.sort(Package.compare);
+
+        const expected = [
+            EXPECT_PACKAGE.recommended1,
+            EXPECT_PACKAGE.recommended2,
+            EXPECT_PACKAGE.test_insiders,
+            EXPECT_PACKAGE.user,
+        ];
+
+        assert.containSubset(packages, expected);
+        assert.lengthOf(packages, expected.length);
+    });
+
     test('Invalid user config: wrong type', async function() {
         stubGlobalConfiguration('privateExtensions', {
             registries: 42,
         });
 
         const provider = new RegistryProvider();
-        const type = 'Array<{ name: string, registry?: string, channels?: object }>';
+        const type = 'Array<{ name: string, registry?: string }>';
 
         assert.throws(
             () => {
@@ -212,6 +231,18 @@ const USER_REGISTRY_CONFIG = {
     ],
 };
 
+const USER_REGISTRY_CONFIG_CHNL = {
+    registries: [
+        {
+            name: 'User Registry',
+            registry: USER_REGISTRY_URL,
+        },
+    ],
+    channels: {
+        test: 'insiders',
+    },
+};
+
 const WORKSPACE_SEARCH: Record<string, search.Result> = {
     test: {
         name: 'test',
@@ -242,7 +273,7 @@ const USER_SEARCH: Record<string, search.Result> = {
 const WORKSPACE_PACKAGE: Record<string, PackageMetadata> = {
     test: {
         name: 'test',
-        'dist-tags': { latest: '1.0.0' },
+        'dist-tags': { latest: '1.0.0', insiders: '2.0.0-beta.0' },
         versions: {
             '1.0.0': {
                 publisher: 'Test',
@@ -252,6 +283,17 @@ const WORKSPACE_PACKAGE: Record<string, PackageMetadata> = {
                 dist: {
                     shasum: 'TODO',
                     tarball: WORKSPACE_REGISTRY_URL + 'test/-/test-1.0.0.tgz',
+                },
+                files: ['extension.vsix'],
+            },
+            '2.0.0-beta.0': {
+                publisher: 'Test',
+                name: 'test',
+                version: '2.0.0-beta.0',
+                engines: { vscode: '1.38.0' },
+                dist: {
+                    shasum: 'TODO',
+                    tarball: WORKSPACE_REGISTRY_URL + 'test/-/test-2.0.0-beta.0.tgz',
                 },
                 files: ['extension.vsix'],
             },
@@ -330,6 +372,11 @@ const USER_PACKAGE: Record<string, PackageMetadata> = {
 const EXPECT_PACKAGE: Record<string, Partial<Package>> = {
     test: {
         extensionId: 'test.test',
+        version: new SemVer('1.0.0'),
+    },
+    test_insiders: {
+        extensionId: 'test.test',
+        version: new SemVer('2.0.0-beta.0'),
     },
     recommended1: {
         extensionId: 'test.recommended1',

--- a/extension/src/views/extensionDetailsView.ts
+++ b/extension/src/views/extensionDetailsView.ts
@@ -129,6 +129,9 @@ export class ExtensionDetailsView extends WebView<ExtensionData> {
                             )}">
                                 ${this.pkg.extensionId}
                             </span>
+                            <span class="identifier" title="${localize('extension.channel', 'Extension channel')}">
+                                ${this.pkg.channel}
+                            </span>
                         </div>
                         <div class="subtitle">
                             <span class="publisher" title="${localize('publisher', 'Publisher')}">


### PR DESCRIPTION
Allows channels to be specified for each extension in a repository based on the package
ID.  Expects that pre-release versions are pushed with a --tag='channelName' to set
the dist-tag appropriately.  If not specified, the 'latest' channel is used by default.

Could also update the extension info view to indicate which channels are available for
tracking and couple this to a command that allows switching between channels w/o
manually editing settings.

See #2