### PR TITLE
Support for OS specific VSIX files

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -96,6 +96,24 @@ user's machine, you should build them yourself for each supported platform and
 include them in the .vsix or host them on a server and have your extension
 download them at runtime.
 
+### OS specific Extensions
+
+Use optional `osSpecificVsix` to choose a .vsix file by the [operating system](https://nodejs.org/api/os.html#os_os_platform):
+
+```JSON
+    ...
+    "osSpecificVsix": {
+        "linux": "extension-linux.vsix",
+        "win32": "extension-win32.vsix",
+        "default": "extension-default.vsix",
+    },
+    ...
+```
+
+The package must include all files listed. `default` (*optional*) is used to select
+a file in case none of the explicit keys matches; otherwise an error is shown on
+unsupported platforms.
+
 ## Discovering Extensions
 
 Now that your extensions are published to an NPM registry, you need to tell

--- a/extension/README.md
+++ b/extension/README.md
@@ -98,7 +98,9 @@ download them at runtime.
 
 ### OS specific Extensions
 
-Use optional `osSpecificVsix` to choose a .vsix file by the [operating system](https://nodejs.org/api/os.html#os_os_platform):
+By default, the first .vsix file in the files array is used. If you have different
+native dependencies for each platform, you can use osSpecificVsix to choose a .vsix
+file by the [operating system](https://nodejs.org/api/os.html#os_os_platform).
 
 ```JSON
     ...

--- a/extension/src/Package.ts
+++ b/extension/src/Package.ts
@@ -125,7 +125,7 @@ export class Package {
     /* The channel that this package is tracking */
     public readonly channel: string;
 
-    private readonly vsixFile: Result<string>;
+    private readonly _vsixFile: Result<string>;
     private readonly isPublisherValid: boolean;
 
     private _isInstalled = false;
@@ -169,7 +169,7 @@ export class Package {
         // if the extension is already installed.
         this._isUiExtension = isUiExtension(this.extensionId, manifest);
 
-        this.vsixFile = findVsixFile(manifest);
+        this._vsixFile = findVsixFile(manifest);
     }
 
     /**
@@ -195,7 +195,7 @@ export class Package {
      * Call `updateState()` first to ensure this is up-to-date.
      */
     public get state(): PackageState {
-        if (this.isPublisherValid && valueOrNull(this.vsixFile)) {
+        if (this.isPublisherValid && this.vsixFile) {
             if (this.isUpdateAvailable) {
                 return PackageState.UpdateAvailable;
             }
@@ -229,8 +229,8 @@ export class Package {
         if (!this.isPublisherValid) {
             return localize('manifest.missing.publisher', 'Manifest is missing "publisher" field.');
         }
-        if (this.vsixFile.type === 'error') {
-            return this.vsixFile.error.message;
+        if (this._vsixFile.type === 'error') {
+            return this._vsixFile.error.message;
         }
         return '';
     }
@@ -277,6 +277,14 @@ export class Package {
         return !!this.installedVersion && this.version > this.installedVersion;
     }
 
+    /**
+     * Gets the .vsix file or `null`, if the package doesn't contain a
+     * suitable file.
+     */
+    public get vsixFile(): string | null {
+        return valueOrNull(this._vsixFile);
+    }
+
     public toString(): string {
         return this.displayName;
     }
@@ -292,7 +300,7 @@ export class Package {
         changelog: vscode.Uri | null;
     }> {
         const directory = await this.registry.downloadPackage(this);
-        const vsix = valueOrNull(this.vsixFile);
+        const vsix = this.vsixFile;
 
         return {
             manifest: uriJoin(directory, 'package.json'),

--- a/extension/src/Package.ts
+++ b/extension/src/Package.ts
@@ -51,6 +51,7 @@ const PackageManifest = options(
         description: t.string,
         version: t.string,
         files: t.array(t.string),
+        osSpecific: t.record(t.string, t.string)
     },
 );
 type PackageManifest = t.TypeOf<typeof PackageManifest>;
@@ -286,6 +287,20 @@ function uriJoin(directory: vscode.Uri, file: string) {
 
 function findVsixFile(manifest: PackageManifest) {
     if (manifest.files) {
+        if (manifest.osSpecific) {
+            const os = require("os");
+            const osEntry = manifest.osSpecific[os.platform()];
+
+            if (osEntry) {
+                const osSpecificFile = manifest.files.find(e => (e === osEntry && typeof e === 'string' && e.endsWith('.vsix')));
+
+                if (osSpecificFile) {
+                    return osSpecificFile;
+                }
+            }
+            return null;
+        }
+
         for (const file of manifest.files) {
             if (typeof file === 'string' && file.endsWith('.vsix')) {
                 return file;

--- a/extension/src/Package.ts
+++ b/extension/src/Package.ts
@@ -1,5 +1,6 @@
 import * as _glob from 'glob';
 import * as t from 'io-ts';
+import * as os from 'os';
 import * as path from 'path';
 import { parse as parseVersion, SemVer } from 'semver';
 import { promisify } from 'util';
@@ -39,6 +40,33 @@ export enum PackageState {
 export class NotAnExtensionError extends Error {}
 
 /**
+ * Represents a result containing a value.
+ */
+type ResultSuccess<T> = { type: 'success'; value: T };
+
+/**
+ * Represents a result containing an error.
+ */
+type ResultError = { type: 'error'; error: Error };
+
+/**
+ * Type that contains a value if successful or an error otherwise.
+ */
+type Result<T> = ResultSuccess<T> | ResultError;
+
+function valueOrNull<T>(result: Result<T>): T | null {
+    return result.type === 'success' ? result.value : null;
+}
+
+function success<T>(value: T): ResultSuccess<T> {
+    return { type: 'success', value: value };
+}
+
+function error(message: string): ResultError {
+    return { type: 'error', error: new Error(message) };
+}
+
+/**
  * Fields expected for all NPM packages.
  */
 const PackageManifest = options(
@@ -51,7 +79,7 @@ const PackageManifest = options(
         description: t.string,
         version: t.string,
         files: t.array(t.string),
-        osSpecific: t.record(t.string, t.string)
+        osSpecificVsix: t.record(t.string, t.string),
     },
 );
 type PackageManifest = t.TypeOf<typeof PackageManifest>;
@@ -97,7 +125,7 @@ export class Package {
     /* The channel that this package is tracking */
     public readonly channel: string;
 
-    private readonly vsixFile: string | null;
+    private readonly vsixFile: Result<string>;
     private readonly isPublisherValid: boolean;
 
     private _isInstalled = false;
@@ -167,7 +195,7 @@ export class Package {
      * Call `updateState()` first to ensure this is up-to-date.
      */
     public get state(): PackageState {
-        if (this.isPublisherValid && this.vsixFile) {
+        if (this.isPublisherValid && valueOrNull(this.vsixFile)) {
             if (this.isUpdateAvailable) {
                 return PackageState.UpdateAvailable;
             }
@@ -201,8 +229,8 @@ export class Package {
         if (!this.isPublisherValid) {
             return localize('manifest.missing.publisher', 'Manifest is missing "publisher" field.');
         }
-        if (!this.vsixFile) {
-            return localize('manifest.missing.vsix', 'Manifest is missing .vsix file in "files" field.');
+        if (this.vsixFile.type === 'error') {
+            return this.vsixFile.error.message;
         }
         return '';
     }
@@ -264,10 +292,11 @@ export class Package {
         changelog: vscode.Uri | null;
     }> {
         const directory = await this.registry.downloadPackage(this);
+        const vsix = valueOrNull(this.vsixFile);
 
         return {
             manifest: uriJoin(directory, 'package.json'),
-            vsix: this.vsixFile ? uriJoin(directory, this.vsixFile) : null,
+            vsix: vsix ? uriJoin(directory, vsix) : null,
             readme: await findFile(directory, README_GLOB),
             changelog: await findFile(directory, CHANGELOG_GLOB),
         };
@@ -285,30 +314,32 @@ function uriJoin(directory: vscode.Uri, file: string) {
     return vscode.Uri.file(path.join(directory.fsPath, file));
 }
 
-function findVsixFile(manifest: PackageManifest) {
+function findVsixFile(manifest: PackageManifest): Result<string> {
     if (manifest.files) {
-        if (manifest.osSpecific) {
-            const os = require("os");
-            const osEntry = manifest.osSpecific[os.platform()];
+        if (manifest.osSpecificVsix) {
+            const vsix = manifest.osSpecificVsix[os.platform()] ?? manifest.osSpecificVsix['default'];
 
-            if (osEntry) {
-                const osSpecificFile = manifest.files.find(e => (e === osEntry && typeof e === 'string' && e.endsWith('.vsix')));
-
-                if (osSpecificFile) {
-                    return osSpecificFile;
-                }
+            if (vsix) {
+                return success(vsix);
             }
-            return null;
+
+            return error(
+                localize(
+                    'manifest.missing.os.vsix',
+                    'Manifest is missing .vsix file in "osSpecificVsix" field for "{0}".',
+                    os.platform(),
+                ),
+            );
         }
 
         for (const file of manifest.files) {
             if (typeof file === 'string' && file.endsWith('.vsix')) {
-                return file;
+                return success(file);
             }
         }
     }
 
-    return null;
+    return error(localize('manifest.missing.vsix', 'Manifest is missing .vsix file in "files" field.'));
 }
 
 /**

--- a/extension/src/test/suite/package.test.ts
+++ b/extension/src/test/suite/package.test.ts
@@ -1,7 +1,6 @@
 import { assert } from 'chai';
 import { afterEach, beforeEach } from 'mocha';
 import * as os from 'os';
-import * as path from 'path';
 import { SemVer } from 'semver';
 import sinon = require('sinon');
 import 'source-map-support/register';
@@ -782,9 +781,7 @@ suite('Package', function () {
             files: ['extension.vsix'],
         });
 
-        const directory = await pkg.registry.downloadPackage(pkg);
-        const expected = vscode.Uri.file(path.join(directory.fsPath, 'extension.vsix'));
-        assert.equal((await pkg.getContents()).vsix?.toString(), expected.toString());
+        assert.deepInclude(pkg, {vsixFile: 'extension.vsix'});
     });
 
     test('Vsix file: OS specific setting returns specific file', async function () {
@@ -803,9 +800,7 @@ suite('Package', function () {
             },
         });
 
-        const directory = await pkg.registry.downloadPackage(pkg);
-        const expected = vscode.Uri.file(path.join(directory.fsPath, 'correct_file.vsix'));
-        assert.equal((await pkg.getContents()).vsix?.toString(), expected.toString());
+        assert.deepInclude(pkg, {vsixFile: 'correct_file.vsix'});
     });
 
     test('Vsix file: OS specific setting but no supported OS', async function () {
@@ -820,7 +815,7 @@ suite('Package', function () {
             osSpecificVsix: { unrelated_os: 'extension.vsix' },
         });
 
-        assert.isNull((await pkg.getContents()).vsix);
+        assert.deepInclude(pkg, {vsixFile: null});
         await pkg.updateState();
 
         assert.deepInclude(pkg, {
@@ -844,7 +839,7 @@ suite('Package', function () {
             osSpecificVsix: {},
         });
 
-        assert.isNull((await pkg.getContents()).vsix);
+        assert.deepInclude(pkg, {vsixFile: null});
     });
 
     test('Vsix file: Default if no matching OS', async function () {
@@ -862,8 +857,6 @@ suite('Package', function () {
             },
         });
 
-        const directory = await pkg.registry.downloadPackage(pkg);
-        const expected = vscode.Uri.file(path.join(directory.fsPath, 'default_extension.vsix'));
-        assert.equal((await pkg.getContents()).vsix?.toString(), expected.toString());
+        assert.deepInclude(pkg, {vsixFile: 'default_extension.vsix'});
     });
 });

--- a/extension/src/test/suite/package.test.ts
+++ b/extension/src/test/suite/package.test.ts
@@ -1,12 +1,12 @@
 import { assert } from 'chai';
 import { afterEach, beforeEach } from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
 import { SemVer } from 'semver';
 import sinon = require('sinon');
-import os = require('os')
 import 'source-map-support/register';
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls/node';
-import * as path from 'path';
 
 import { ExtensionInfoService } from '../../extensionInfo';
 import { NotAnExtensionError, Package, PackageState } from '../../Package';
@@ -783,7 +783,7 @@ suite('Package', function () {
         });
 
         const directory = await pkg.registry.downloadPackage(pkg);
-        const expected = vscode.Uri.file(path.join(directory.fsPath, "extension.vsix"));
+        const expected = vscode.Uri.file(path.join(directory.fsPath, 'extension.vsix'));
         assert.equal((await pkg.getContents()).vsix?.toString(), expected.toString());
     });
 
@@ -797,31 +797,15 @@ suite('Package', function () {
             version: '1.2.3',
             engines: { vscode: '1.38.0' },
             files: ['z_wrong_file.vsix', 'unrelated.vsix', 'correct_file.vsix', 'a_wrong_file.vsix'],
-            osSpecific: {
+            osSpecificVsix: {
                 [expectedPlatform]: 'correct_file.vsix',
-                unrelated_os: 'unrelated.vsix'
+                unrelated_os: 'unrelated.vsix',
             },
         });
 
         const directory = await pkg.registry.downloadPackage(pkg);
-        const expected = vscode.Uri.file(path.join(directory.fsPath, "correct_file.vsix"));
+        const expected = vscode.Uri.file(path.join(directory.fsPath, 'correct_file.vsix'));
         assert.equal((await pkg.getContents()).vsix?.toString(), expected.toString());
-    });
-
-    test('Vsix file: OS specific setting but missing file', async function () {
-        stubs.stubExtension('test.test-package');
-
-        const expectedPlatform = os.platform();
-        const pkg = new Package(getDummyRegistry(), {
-            name: 'test-package',
-            publisher: 'Test',
-            version: '1.2.3',
-            engines: { vscode: '1.38.0' },
-            files: ['z_wrong_file.vsix', 'a_wrong_file.vsix'],
-            osSpecific: { [expectedPlatform]: 'missing_in_files.vsix'},
-        });
-
-        assert.isNull((await pkg.getContents()).vsix);
     });
 
     test('Vsix file: OS specific setting but no supported OS', async function () {
@@ -832,11 +816,20 @@ suite('Package', function () {
             publisher: 'Test',
             version: '1.2.3',
             engines: { vscode: '1.38.0' },
-            files: ['extension_1.vsix', 'extension_2.vsix'],
-            osSpecific: { unrelated_os: 'extension_1.vsix'},
+            files: ['extension.vsix'],
+            osSpecificVsix: { unrelated_os: 'extension.vsix' },
         });
 
         assert.isNull((await pkg.getContents()).vsix);
+        await pkg.updateState();
+
+        assert.deepInclude(pkg, {
+            state: PackageState.Invalid,
+            errorMessage:
+                '\uFF3BMaaniifeest iis miissiing .vsiix fiilee iin "oosSpeeciifiicVsiix" fiieeld foor "' +
+                os.platform() +
+                '".\uFF3D',
+        });
     });
 
     test('Vsix file: Empty OS specific setting', async function () {
@@ -848,9 +841,29 @@ suite('Package', function () {
             version: '1.2.3',
             engines: { vscode: '1.38.0' },
             files: ['extension.vsix'],
-            osSpecific: { },
+            osSpecificVsix: {},
         });
 
         assert.isNull((await pkg.getContents()).vsix);
+    });
+
+    test('Vsix file: Default if no matching OS', async function () {
+        stubs.stubExtension('test.test-package');
+
+        const pkg = new Package(getDummyRegistry(), {
+            name: 'test-package',
+            publisher: 'Test',
+            version: '1.2.3',
+            engines: { vscode: '1.38.0' },
+            files: ['extension.vsix'],
+            osSpecificVsix: {
+                unrelated_os: 'extension_1.vsix',
+                default: 'default_extension.vsix',
+            },
+        });
+
+        const directory = await pkg.registry.downloadPackage(pkg);
+        const expected = vscode.Uri.file(path.join(directory.fsPath, 'default_extension.vsix'));
+        assert.equal((await pkg.getContents()).vsix?.toString(), expected.toString());
     });
 });

--- a/extension/src/test/suite/package.test.ts
+++ b/extension/src/test/suite/package.test.ts
@@ -821,9 +821,7 @@ suite('Package', function () {
         assert.deepInclude(pkg, {
             state: PackageState.Invalid,
             errorMessage:
-                '\uFF3BMaaniifeest iis miissiing .vsiix fiilee iin "oosSpeeciifiicVsiix" fiieeld foor "' +
-                os.platform() +
-                '".\uFF3D',
+                `\uFF3BMaaniifeest iis miissiing .vsiix fiilee iin "oosSpeeciifiicVsiix" fiieeld foor "${os.platform}".\uFF3D`,
         });
     });
 


### PR DESCRIPTION
Adds an optional field to select a .vsix file depending on the OS (#36).

This enables OS specific extensions with same name and version in the registry. All .vsix files are included in `files`, but the the actual used on is determined by the `osSpecific` field – a map of [OS identifiers](https://nodejs.org/api/os.html#os_os_platform) and filenames.

#### Todo

- [x] `osSpecific` suitable name? --> `osSpecificVsix`
- [x] Update documentation
- [x] Add *default* os
- [x] Improve error handling