### PR TITLE
Add support for insecure content

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -77,6 +77,12 @@
                     "scope": "machine",
                     "description": "%configuration.updateCheckInterval.description%",
                     "default": 3600
+                },
+                "privateExtensions.allowInsecureContent": {
+                    "type": "boolean",
+                    "scope": "machine",
+                    "description": "%configuration.allowInsecureContent.description%",
+                    "default": false
                 }
             }
         },

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -3,6 +3,7 @@
     "configuration.registries.description": "NPM registries containing private extensions. Same format as \"registries\" in extensions.private.json.",
     "configuration.channels.description": "Channels to track for each extension. Keys are the extension package name and values are the target channel. By default extensions track the 'latest' channel.",
     "configuration.updateCheckInterval.description": "Number of seconds between checks for updates to private extensions. Set to 0 to disable automatic update checks.",
+    "configuration.allowInsecureContent.description": "Allow insecure content in Extension Description view",
     "command.cache.delete.title": "Delete NPM Cache",
     "command.cache.garbageCollect.title": "Garbage Collect NPM Cache",
     "command.category": "Private Extensions",

--- a/extension/src/views/webView.ts
+++ b/extension/src/views/webView.ts
@@ -108,10 +108,16 @@ export abstract class WebView<T> implements Disposable {
     protected async getHead(nonce: string): Promise<string> {
         const cspSource = this.panel?.webview.cspSource ?? '';
 
+        const allowInsecure = vscode.workspace
+            .getConfiguration('privateExtensions')
+            .get<boolean>('allowInsecureContent');
+
+        const allowedProtocol = allowInsecure ? 'http' : 'https';
+
         const policy = [
             `default-src 'none';`,
             `font-src ${cspSource};`,
-            `img-src ${cspSource} https:;`,
+            `img-src ${cspSource} ${allowedProtocol}:;`,
             `script-src 'nonce-${nonce}';`,
             `style-src ${cspSource} 'unsafe-inline';`,
         ].join('');


### PR DESCRIPTION
Hello! 
As npm servers do not allow to upload images along the README file, the only possibility is to store the images externally. Since creating a recognized certificate just to host a couple of images internally may be too much hassle, I thought it may be a good idea to add to this extension the optional possibility to accept `http` content inside markdown preview.
Here's an implementation of this idea, it doesn't induce much changes in the code.