### PR TITLE
Loads Registries and Recommendations from a Global Config File

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -188,6 +188,17 @@ as the `registries` array in `extensions.private.json`.
 You can use the **Private Extensions: Add Registry...** and
 **Private Extensions: Remove Registry** commands to quickly edit this setting.
 
+### Global Configuration
+
+Registries and recommendations can also be read from a file `extensions.private.json` in the extension's storage folder:
+
+-   Windows: `%appdata%\\Code\\User\\globalStorage\\garmin.private-extension-manager`
+-   Linux: `~/.vscode-server/data/User/globalStorage/garmin.private-extension-manager`
+
+This file allows for setting registries and recommendations for a user, but separate from their personal VS Code user settings. The global configuration is aimed at organisations being able to set registries and recommendation for all users by placing this file in each user's global storage folder, such as with a group policy.
+
+The file is read only on launch of VS Code as it shouldn't be getting changed too often, so if changes are made then you'll need to do a restart. It has the same format as the workspace configuration file.
+
 ### Custom Channels
 
 It is possible to create tracking channels by using npm dist-tags when

--- a/extension/src/RegistryProvider.ts
+++ b/extension/src/RegistryProvider.ts
@@ -66,10 +66,18 @@ export class RegistryProvider implements Disposable {
 
         this.onDidChangeRegistries(() => {
             const logger = getLogger();
+            logger.log("===== Registries Refreshed =====")
             logger.log("Registries:");
-            logger.log(JSON.stringify(this.getRegistries()));
+            logger.log(JSON.stringify(
+                this.getRegistries().map((reg) => {
+                    return { name: reg.name, uri: reg.uri, pagination: reg.enablePagination, query: reg.query }
+                }),
+                null,
+                2
+            ));
             logger.log("Recommended extensions:");
-            logger.log(JSON.stringify(this.getRecommendedExtensions()));
+            logger.log("\t" + Array.from(this.getRecommendedExtensions()).join(",\n\t"));
+            logger.log("\n");
         });
     }
 

--- a/extension/src/commands/configCommands.ts
+++ b/extension/src/commands/configCommands.ts
@@ -71,7 +71,10 @@ async function writeTemplateIfEmpty(editor: vscode.TextEditor) {
     }
 
     await editor.edit((editBuilder) => {
-        editBuilder.insert(new vscode.Position(0, 0), ExtensionsConfigurationInitialContent);
+        editBuilder.insert(new vscode.Position(0, 0), ExtensionsConfigurationInitialContent([
+            "This file configures the private extension manager for users of this workspace.",
+            "users of this workspace"
+        ]));
     });
 
     await editor.document.save();

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as nls from 'vscode-nls/node';
+import * as fs from 'fs';
 
 import { CommandManager } from './commandManager';
 import * as commands from './commands/index';
@@ -21,6 +22,11 @@ nls.config({ messageFormat: nls.MessageFormat.file })();
 
 export function activate(context: vscode.ExtensionContext): void {
     setContext(context);
+    try {
+        fs.accessSync(context.globalStorageUri.fsPath)
+    } catch {
+        fs.mkdirSync(context.globalStorageUri.fsPath);
+    }
 
     const extensionInfo = new ExtensionInfoService();
     const registryProvider = new RegistryProvider(extensionInfo);

--- a/extension/src/extensionsFileTemplate.ts
+++ b/extension/src/extensionsFileTemplate.ts
@@ -3,18 +3,19 @@
 
 export const ExtensionsConfigurationFilePath = '.vscode/extensions.private.json';
 
-export const ExtensionsConfigurationInitialContent = `{
-\t// This file configures the private extension manager for users of this workspace.
+export const ExtensionsConfigurationInitialContent = (desc: string[]) => `{
+\t// ${desc[0]}
 \t// Extension identifier format: \${publisher}.\${name}. Example: vscode.csharp
 
 \t// List of NPM registries containing private extensions.
-\t// Each item should have a "name", a "registry" URL, and optionally a "query" to
-\t// filter which extensions are shown.
+\t// Each item should have a "name", a "registry" URL.
+\t// Optional parameters are "query" to filter which extensions are shown, and
+\t// "pagination" to disable pagination for registries that do not support it e.g. Artifactory 6.
 \t// See https://www.npmjs.com/package/npm-registry-fetch#fetch-opts for extra
 \t// options including authentication.
 \t"registries": [
 \t],
-\t// List of private extensions which should be recommended for users of this workspace.
+\t// List of private extensions which should be recommended for ${desc[1]}.
 \t"recommendations": [
 \t]
 }`;


### PR DESCRIPTION
This allows Private Extension Manager to load extensions from a file called `extensions.private.json` in the extension's global storage folder. It has the same format as for the workspace configuration file.

I created this because my organisation wants to be able to set our registry for everyone without them having to faff with setting it up themselves, and also wants to be able to set recommendations for all of them e.g. GitLens.

Also added in a few lines to log registries and recommendations to the console whenever registries are refreshed.

Let me know if there are any functional or styling changes that I should make.