### PR TITLE
autoReload after an event on an Extension

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1413,6 +1413,7 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -82,6 +82,12 @@
                     "scope": "machine",
                     "description": "%configuration.allowInsecureContent.description%",
                     "default": false
+                },
+                "privateExtensions.autoReload": {
+                    "type": "boolean",
+                    "scope": "machine",
+                    "description": "%configuration.autoReload.description%",
+                    "default": false
                 }
             }
         },

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -4,6 +4,7 @@
     "configuration.channels.description": "Channels to track for each extension. Keys are the extension package name and values are the target channel. By default extensions track the 'latest' channel.",
     "configuration.updateCheckInterval.description": "Number of seconds between checks for updates to private extensions. Set to 0 to disable automatic update checks.",
     "configuration.allowInsecureContent.description": "Allow insecure content in Extension Description view",
+    "configuration.autoReload.description": "Controls if VSCode should automatically reload after the installation/uninstallation of an extension instead of requested it to the user",
     "command.cache.delete.title": "Delete NPM Cache",
     "command.cache.garbageCollect.title": "Garbage Collect NPM Cache",
     "command.category": "Private Extensions",

--- a/extension/src/commands/extensionCommands.ts
+++ b/extension/src/commands/extensionCommands.ts
@@ -72,8 +72,8 @@ export class UpdateExtensionCommand implements Command {
         if (!(await this.extensionInfo.didExtensionUpdate(pkg))) {
             await install.showReloadPrompt(
                 localize(
-                    'reload.to.complete.update',
-                    'Please reload Visual Studio Code to complete updating the extension {0}.',
+                    'to.complete.update',
+                    'to complete updating the extension {0}.',
                     pkg.displayName,
                 ),
             );
@@ -97,8 +97,8 @@ export class UninstallExtensionCommand implements Command {
         if (await this.extensionInfo.getExtension(extensionId)) {
             await install.showReloadPrompt(
                 localize(
-                    'reload.to.complete.uninstall',
-                    'Please reload Visual Studio Code to complete uninstalling the extension {0}.',
+                    'to.complete.uninstall',
+                    'to complete uninstalling the extension {0}.',
                     extensionId,
                 ),
             );
@@ -317,8 +317,8 @@ function installExtension(provider: RegistryProvider, extensionOrId: Package | s
 async function showInstallReloadPrompt(pkg: Package) {
     return await install.showReloadPrompt(
         localize(
-            'reload.to.complete.install',
-            'Please reload Visual Studio Code to complete installing the extension {0}.',
+            'to.complete.install',
+            'to complete installing the extension {0}.',
             pkg.displayName,
         ),
     );

--- a/extension/src/util.ts
+++ b/extension/src/util.ts
@@ -122,3 +122,12 @@ export function uriEquals(a: Uri, b: Uri): boolean {
 export function formatExtensionId(publisher: string, name: string): string {
     return `${publisher}.${name}`.toLowerCase();
 }
+
+/**
+ * Returns a Promise that will resolve in after the given duration.
+ *
+ * @param durationInMs The duration to wait, in ms.
+ */
+ export function sleep(durationInMs: number) {
+    return new Promise(resolve => setTimeout(resolve, durationInMs));
+  }


### PR DESCRIPTION
In our company we have automatize the installation of several private extension, but due to the popin to ask to reload VSCode, the process is blocked. 
To avoid user interaction, we would like to let automatically reload VSCode when it's needed.
