### PR TITLE
Add silent option

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1413,6 +1413,7 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1413,7 +1413,6 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",

--- a/extension/src/commands/extensionCommands.ts
+++ b/extension/src/commands/extensionCommands.ts
@@ -27,6 +27,13 @@ export class ShowExtensionCommand implements Command {
 }
 
 /**
+ * Options received at execution of a command
+ */
+export interface ExtensionCommandOptions {
+    silent?: boolean;
+}
+
+/**
  * Installs an extension.
  */
 export class InstallExtensionCommand implements Command {
@@ -37,14 +44,14 @@ export class InstallExtensionCommand implements Command {
         private readonly extensionInfo: ExtensionInfoService,
     ) {}
 
-    public async execute(extensionOrId: Package | string): Promise<void> {
+    public async execute(extensionOrId: Package | string, options?: ExtensionCommandOptions): Promise<void> {
         const pkg = await this.extensionInfo.waitForExtensionChange(
             installExtension(this.registryProvider, extensionOrId),
         );
 
         // If vscode could immediately load the extension, it should be visible
         // to the extensions API now. If not, we need to reload.
-        if (!(await this.extensionInfo.getExtension(pkg.extensionId))) {
+        if (!options?.silent && !(await this.extensionInfo.getExtension(pkg.extensionId))) {
             await showInstallReloadPrompt(pkg);
         }
     }


### PR DESCRIPTION
Following the discussion on this PR https://github.com/joelspadin-garmin/vscode-private-extension-manager/pull/58, there the implementation to don't show the ReloadPrompt.
