### PR TITLE
Improve npm data fetching with fast list and lazy metadata loading

### DIFF
--- a/extension/src/Registry.ts
+++ b/extension/src/Registry.ts
@@ -109,10 +109,18 @@ export class Registry {
         return nameA < nameB ? -1 : nameA > nameB ? 1 : 0;
     }
 
+    private static readonly METADATA_CONCURRENCY = 10;
+
     public readonly query: string | string[];
     public readonly enablePagination: boolean;
 
     public readonly options: Partial<Options>;
+
+    /**
+     * In-memory cache of in-flight or completed metadata fetches, keyed by escaped package name.
+     * Storing the Promise directly deduplicates concurrent requests for the same package.
+     */
+    private readonly metadataCache = new Map<string, Promise<Record<string, unknown>>>();
 
     constructor(
         public readonly extensionInfo: ExtensionInfoService,
@@ -233,10 +241,85 @@ export class Registry {
 
     /**
      * Gets the full package metadata for a package.
+     *
+     * Results are cached in memory for the lifetime of this Registry instance.
+     * Concurrent calls for the same package share the same in-flight request.
      */
     public async getPackageMetadata(name: string): Promise<Record<string, unknown>> {
         const spec = npa(name);
-        return await npmfetch.json(`/${spec.escapedName}`, this.options);
+        const key = spec.escapedName ?? name;
+
+        if (!this.metadataCache.has(key)) {
+            const p = npmfetch.json(`/${key}`, this.options) as Promise<Record<string, unknown>>;
+            this.metadataCache.set(key, p);
+            // Evict failed requests so they can be retried.
+            p.catch(() => this.metadataCache.delete(key));
+        }
+
+        return this.metadataCache.get(key)!;
+    }
+
+    /**
+     * Returns search results for all packages matching the registry's query,
+     * without fetching per-package metadata. Use this to show the initial list
+     * quickly, then call {@link loadPackages} in the background for full details.
+     */
+    public async getSearchList(token?: CancellationToken): Promise<npmsearch.Result[]> {
+        const results: npmsearch.Result[] = [];
+        for await (const result of this.findMatchingPackages(this.query, token)) {
+            if (token?.isCancellationRequested) {
+                break;
+            }
+            results.push(result);
+        }
+        return results;
+    }
+
+    /**
+     * Fetches full package metadata for the given package names in parallel
+     * and returns the resolved {@link Package} objects. Packages that fail to
+     * load (e.g. not a VS Code extension) are silently skipped or logged.
+     *
+     * Call this after {@link getSearchList} to enrich the initial quick list.
+     */
+    public async loadPackages(names: string[], token?: CancellationToken): Promise<Package[]> {
+        const packages: Package[] = [];
+
+        for (let i = 0; i < names.length; i += Registry.METADATA_CONCURRENCY) {
+            if (token?.isCancellationRequested) {
+                break;
+            }
+
+            const batch = names.slice(i, i + Registry.METADATA_CONCURRENCY);
+            const results = await Promise.all(
+                batch.map(async (n) => {
+                    try {
+                        return await this.getPackage(n);
+                    } catch (ex) {
+                        if (!(ex instanceof NotAnExtensionError)) {
+                            getLogger().log(
+                                localize(
+                                    'warn.discarding.package',
+                                    'Warning: Discarding package {0}:\n{1}',
+                                    n,
+                                    toString(ex),
+                                ),
+                            );
+                        }
+                        return undefined;
+                    }
+                }),
+            );
+
+            for (const pkg of results) {
+                if (pkg !== undefined) {
+                    packages.push(pkg);
+                }
+            }
+        }
+
+        await Promise.all(packages.map((pkg) => pkg.updateState()));
+        return packages;
     }
 
     /**

--- a/extension/src/views/registryView.ts
+++ b/extension/src/views/registryView.ts
@@ -1,3 +1,4 @@
+import * as npmsearch from 'libnpmsearch';
 import * as vscode from 'vscode';
 import { Disposable, EventEmitter, TreeDataProvider, TreeItem } from 'vscode';
 import * as nls from 'vscode-nls/node';
@@ -86,7 +87,7 @@ export class RegistryView implements Disposable {
     }
 }
 
-type Element = Registry | Package | string;
+type Element = Registry | Package | npmsearch.Result | string;
 
 /**
  * TreeDataProvider for the Extensions section of the sidebar panel.
@@ -98,6 +99,7 @@ class ExtensionsProvider implements TreeDataProvider<Element>, Disposable {
     protected disposable: Disposable;
 
     private children?: Registry[];
+    private registryItems = new Map<Registry, RegistryItem>();
 
     constructor(protected readonly registryProvider: RegistryProvider) {
         this.disposable = Disposable.from(
@@ -112,6 +114,15 @@ class ExtensionsProvider implements TreeDataProvider<Element>, Disposable {
     }
 
     public getTreeItem(element: Element): BaseItem {
+        if (element instanceof Registry) {
+            if (!this.registryItems.has(element)) {
+                this.registryItems.set(
+                    element,
+                    new RegistryItem(element, (item) => this._onDidChangeTreeData.fire(item)),
+                );
+            }
+            return this.registryItems.get(element)!;
+        }
         return elementToNode(element);
     }
 
@@ -124,6 +135,8 @@ class ExtensionsProvider implements TreeDataProvider<Element>, Disposable {
     }
 
     public refresh() {
+        this.registryItems.forEach((item) => item.reset());
+        this.registryItems.clear();
         this.children = undefined;
         this._onDidChangeTreeData.fire(undefined);
     }
@@ -232,27 +245,64 @@ class MessageItem extends BaseItem {
 }
 
 class RegistryItem extends BaseItem {
-    constructor(public readonly registry: Registry) {
+    private enrichedPackages?: Package[];
+    private loading = false;
+
+    constructor(
+        public readonly registry: Registry,
+        private readonly onEnriched: (item: RegistryItem) => void,
+    ) {
         super(registry.name, vscode.TreeItemCollapsibleState.Expanded);
 
         this.contextValue = `registry.${this.registry.source}`;
         this.resourceUri = this.registry.uri;
     }
 
-    public async getExtensions() {
-        const children = await this.registry.getPackages();
-        children.sort(Package.compare);
-        return children;
+    /**
+     * Resets cached state so the next `getChildren()` call starts fresh.
+     */
+    public reset() {
+        this.enrichedPackages = undefined;
+        this.loading = false;
     }
 
     public async getChildren(): Promise<Element[]> {
-        const children = await this.getExtensions();
+        // Phase 2: enrichment already complete — return full Package items.
+        if (this.enrichedPackages) {
+            const sorted = [...this.enrichedPackages].sort(Package.compare);
+            return sorted.length > 0 ? sorted : [NO_EXTENSIONS_MESSAGE];
+        }
 
-        if (children.length > 0) {
-            return children;
-        } else {
+        // Phase 1: get the list from search quickly (no per-package metadata).
+        const results = await this.registry.getSearchList();
+
+        if (results.length === 0) {
             return [NO_EXTENSIONS_MESSAGE];
         }
+
+        // Kick off background metadata fetch once per load cycle.
+        if (!this.loading) {
+            this.loading = true;
+            this.registry.loadPackages(results.map((r) => r.name)).then((pkgs) => {
+                this.enrichedPackages = pkgs;
+                this.onEnriched(this);
+            });
+        }
+
+        // Return search results as elements; getTreeItem() maps them to SearchResultItems.
+        return results;
+    }
+}
+
+/**
+ * A lightweight tree item built from npm search data, shown while full package
+ * metadata loads in the background. Has no state icon or install information.
+ */
+class SearchResultItem extends BaseItem {
+    constructor(result: npmsearch.Result) {
+        super(result.name, vscode.TreeItemCollapsibleState.None);
+        this.description = result.version;
+        this.tooltip = result.description;
     }
 }
 
@@ -290,14 +340,15 @@ class ExtensionItem extends BaseItem {
 }
 
 function elementToNode(element: Element): BaseItem {
-    if (element instanceof Registry) {
-        return new RegistryItem(element);
-    }
     if (element instanceof Package) {
         return new ExtensionItem(element);
     }
     if (typeof element === 'string') {
         return new MessageItem(element);
+    }
+    if (!(element instanceof Registry)) {
+        // npmsearch.Result — shown while metadata loads in the background.
+        return new SearchResultItem(element);
     }
 
     throw new Error('Unexpected object: ' + element);


### PR DESCRIPTION
Show the package list immediately from search results, then fetch full per-package metadata in the background in parallel batches of 10.

- Add in-memory metadata cache to Registry to deduplicate concurrent requests for the same package (evicts on error for retryability)
- Add Registry.getSearchList() to return search results without any per-package metadata calls
- Add Registry.loadPackages() to fetch full metadata in parallel
- Rework RegistryItem in the tree view to use two-phase loading: phase 1 shows SearchResultItem placeholders from search data immediately; phase 2 fires onDidChangeTreeData when enrichment completes to replace placeholders with fully-resolved Package items
- Add SearchResultItem as a lightweight tree item built from search data